### PR TITLE
Fix the build for the share-project

### DIFF
--- a/esign-cert-share/pom.xml
+++ b/esign-cert-share/pom.xml
@@ -81,12 +81,17 @@
     </dependencies>
 
     <build>
-    	<finalName>${artifactId}-${version}</finalName>
+    	<finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
             <!-- Compress JavaScript files and store as *-min.js -->
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>yuicompressor-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.1</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fix removing maven alerts about artifactId and version properties.
Fix the error "Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:2.7:resources (default-resources) on project esign-cert-share: Mark invalid" by increasing the maven-resources-plugin version to the latest one available.