### PR TITLE
Added setTimeout (2000ms) before doSign method in order to wait until…

### DIFF
--- a/esign-cert-share/src/main/amp/config/alfresco/web-extension/site-webscripts/es/keensoft/sign/sign-dialog.get.html.ftl
+++ b/esign-cert-share/src/main/amp/config/alfresco/web-extension/site-webscripts/es/keensoft/sign/sign-dialog.get.html.ftl
@@ -217,7 +217,7 @@
       				    window.clearInterval(loadingSignComponentInterval);
       				    if (!running) {
 	      				    running = true;
-	      				    signFrame.contentWindow.doSign(signForm.dataToSign, signForm.signedData, signForm.signerRole);
+	      				    signFrame.contentWindow.waitToSign(signForm.dataToSign, signForm.signedData, signForm.signerRole);
 	      				}
       				}
 	      		};

--- a/esign-cert-share/src/main/amp/web/sign/sign-frame.jsp
+++ b/esign-cert-share/src/main/amp/web/sign/sign-frame.jsp
@@ -49,6 +49,10 @@
 			}
 
 		<% } %>
+
+		function waitToSign(dataToSign, signedData, signerRole) {
+			setTimeout(function(){ doSign(dataToSign, signedData, signerRole); }, 2000);
+		}
 		
 		function unicodeEscape(str)
   		{


### PR DESCRIPTION
… applet load has ended

Hi Ángel, some notes I wanted to share with you about motivations on this contribution

Despite this humble code makes the applet get loaded in Firefox, i have seen some attemps that **got stuck in the certificate selection window**. I followed the documentation advise on this (Known issues on Firefox +49 for windows 10, page 145) and seems to help, but sometimes still fails, like 5% of the sign attemps...

As the MiniApplet integration manual says, the MiniApplet.cargarMiniApplet method should be called in an early stage of the page load, then a button should be offered to the user in order to call the MiniApplet.sign method, to make sure that cargarMiniApplet has finished. Is also says that it could take some seconds. Instead the addon does the two things sequentially so i think this is the origin of the problem. Not to sure why this is not true for IE

Another thing that I wanted to point is that obviously setTimeout is not a perfect solution, but i think it may help in those scenarios where native application cannot be used.

Take your choice, this may not be interesting for you :)

Regards