### PR TITLE
Migrate from itext to openpdf as openpdf is LGPL

### DIFF
--- a/esign-cert-repo/pom.xml
+++ b/esign-cert-repo/pom.xml
@@ -56,11 +56,13 @@
         <artifactId>xmlworker</artifactId>
         <version>5.0.6</version>
     </dependency> -->
-    <dependency>
-        <groupId>com.itextpdf</groupId>
-        <artifactId>itextpdf</artifactId>
-        <version>5.5.13</version>
-    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.github.librepdf/openpdf -->
+	<dependency>
+	    <groupId>com.github.librepdf</groupId>
+	    <artifactId>openpdf</artifactId>
+	    <version>1.2.21</version>
+	</dependency>
+
 
     </dependencies>
 

--- a/esign-cert-repo/src/main/java/es/alfatec/alfresco/AlfatecSignUtils.java
+++ b/esign-cert-repo/src/main/java/es/alfatec/alfresco/AlfatecSignUtils.java
@@ -28,11 +28,11 @@ import org.alfresco.service.cmr.version.VersionService;
 import org.alfresco.util.TempFileProvider;
 import org.apache.log4j.Logger;
 
-import com.itextpdf.text.DocumentException;
-import com.itextpdf.text.pdf.AcroFields;
-import com.itextpdf.text.pdf.PdfReader;
-import com.itextpdf.text.pdf.PdfStamper;
-import com.itextpdf.text.pdf.security.PdfPKCS7;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.pdf.AcroFields;
+import com.lowagie.text.pdf.PdfPKCS7;
+import com.lowagie.text.pdf.PdfReader;
+import com.lowagie.text.pdf.PdfStamper;
 
 import es.alfatec.alfresco.webscripts.bean.PrintSignatureInformation;
 import es.keensoft.alfresco.model.SignModel;

--- a/esign-cert-repo/src/main/java/es/alfatec/alfresco/WaterMarkUtils.java
+++ b/esign-cert-repo/src/main/java/es/alfatec/alfresco/WaterMarkUtils.java
@@ -1,5 +1,6 @@
 package es.alfatec.alfresco;
 
+import java.awt.Color;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -7,17 +8,16 @@ import java.io.IOException;
 
 import org.alfresco.repo.i18n.MessageService;
 
-import com.itextpdf.text.BaseColor;
-import com.itextpdf.text.Chunk;
-import com.itextpdf.text.DocumentException;
-import com.itextpdf.text.Font;
-import com.itextpdf.text.Font.FontFamily;
-import com.itextpdf.text.Phrase;
-import com.itextpdf.text.Rectangle;
-import com.itextpdf.text.pdf.ColumnText;
-import com.itextpdf.text.pdf.PdfContentByte;
-import com.itextpdf.text.pdf.PdfReader;
-import com.itextpdf.text.pdf.PdfStamper;
+import com.lowagie.text.Chunk;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.Rectangle;
+import com.lowagie.text.pdf.ColumnText;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfReader;
+import com.lowagie.text.pdf.PdfStamper;
 
 public class WaterMarkUtils {
 	private MessageService messageService;
@@ -27,15 +27,15 @@ public class WaterMarkUtils {
 	
 	// Fonts sign
 	private static final float TEXT_SIZE = 7;
-	private static final Font FONT_SIGN = new Font(FontFamily.HELVETICA, TEXT_SIZE, Font.NORMAL, BaseColor.BLACK);
+	private static final Font FONT_SIGN = FontFactory.getFont(FontFactory.HELVETICA, TEXT_SIZE, Font.NORMAL, Color.BLACK);
 	
 	// Fonts CSV
 	private static final float TEXT_SIZE_CSV_1 = 10;
-	private static final Font FONT_CSV_1 = new Font(FontFamily.HELVETICA, TEXT_SIZE_CSV_1, Font.BOLD, BaseColor.BLACK);
+	private static final Font FONT_CSV_1 = FontFactory.getFont(FontFactory.HELVETICA, TEXT_SIZE_CSV_1, Font.BOLD, Color.BLACK);
 	private static final float TEXT_SIZE_CSV_2 = 7;
-	private static final Font FONT_CSV_2 = new Font(FontFamily.HELVETICA, TEXT_SIZE_CSV_2, Font.NORMAL, BaseColor.BLACK);
+	private static final Font FONT_CSV_2 = FontFactory.getFont(FontFactory.HELVETICA, TEXT_SIZE_CSV_2, Font.NORMAL, Color.BLACK);
 	private static final float TEXT_SIZE_CSV_3 = 7;
-	private static final Font FONT_CSV_3 = new Font(FontFamily.HELVETICA, TEXT_SIZE_CSV_3, Font.NORMAL, BaseColor.BLACK);
+	private static final Font FONT_CSV_3 = FontFactory.getFont(FontFactory.HELVETICA, TEXT_SIZE_CSV_3, Font.NORMAL, Color.BLACK);
 	
 	// Sizes sign
 	private static final float RECTANGLE_SIGN_HEIGHT=33;
@@ -88,7 +88,7 @@ public class WaterMarkUtils {
 		// Rectangle sing properties
 		Rectangle signerRectangle = new Rectangle(xLowerLeft, yLowerLeft, xUppeRight, yUppeRight);
 		signerRectangle.setBorder(Rectangle.BOX);
-		signerRectangle.setBorderColor(BaseColor.DARK_GRAY);
+		signerRectangle.setBorderColor(Color.DARK_GRAY);
 		signerRectangle.setBorderWidth(1);
 		
 		// Text with sign information
@@ -194,7 +194,7 @@ public class WaterMarkUtils {
 				// Rectangle properties
 				Rectangle signerRectangle = new Rectangle(xLowerLeft, yLowerLeft, xUppeRight, yUppeRight);
 				signerRectangle.setBorder(Rectangle.BOX);
-				signerRectangle.setBorderColor(BaseColor.DARK_GRAY);
+				signerRectangle.setBorderColor(Color.DARK_GRAY);
 				signerRectangle.setBorderWidth(1);	
 				
 				// CSV Text 

--- a/esign-cert-repo/src/main/java/es/alfatec/alfresco/webscripts/DownloadSignatureReportFile.java
+++ b/esign-cert-repo/src/main/java/es/alfatec/alfresco/webscripts/DownloadSignatureReportFile.java
@@ -15,7 +15,7 @@ import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 import org.springframework.extensions.webscripts.WebScriptResponse;
 
-import com.itextpdf.text.DocumentException;
+import com.lowagie.text.DocumentException;
 
 import es.alfatec.alfresco.AlfatecException;
 import es.alfatec.alfresco.AlfatecSignUtils;

--- a/esign-cert-repo/src/main/java/es/keensoft/alfresco/behaviour/CustomBehaviour.java
+++ b/esign-cert-repo/src/main/java/es/keensoft/alfresco/behaviour/CustomBehaviour.java
@@ -36,9 +36,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.extensions.surf.util.I18NUtil;
 
-import com.itextpdf.text.pdf.AcroFields;
-import com.itextpdf.text.pdf.PdfReader;
-import com.itextpdf.text.pdf.security.PdfPKCS7;
+import com.lowagie.text.pdf.AcroFields;
+import com.lowagie.text.pdf.PdfPKCS7;
+import com.lowagie.text.pdf.PdfReader;
 
 import es.keensoft.alfresco.model.SignModel;
 

--- a/esign-cert-repo/src/test/java/es/keensoft/test/PAdESLTV.java
+++ b/esign-cert-repo/src/test/java/es/keensoft/test/PAdESLTV.java
@@ -13,9 +13,9 @@ import java.util.Map;
 
 import org.alfresco.service.namespace.QName;
 
-import com.itextpdf.text.pdf.AcroFields;
-import com.itextpdf.text.pdf.PdfReader;
-import com.itextpdf.text.pdf.security.PdfPKCS7;
+import com.lowagie.text.pdf.AcroFields;
+import com.lowagie.text.pdf.PdfPKCS7;
+import com.lowagie.text.pdf.PdfReader;
 
 import es.keensoft.alfresco.model.SignModel;
 


### PR DESCRIPTION
itext > 5.0.0 has AGPL licensing model.
Please migrate the project to openpdf LGPL in order to retain freedom.
